### PR TITLE
Rejig API detail page

### DIFF
--- a/source/api_details.html.erb
+++ b/source/api_details.html.erb
@@ -1,19 +1,57 @@
-<h1 id="<%= api.name.parameterize %>"><%= api.name %></h1>
+<h1 id="<%= api.name.parameterize %>">
+  <% if api.name.include? "API" %>
+    <%= api.name %>
+  <% else %>
+    <%= api.name + " API" %>  
+  <% end %>
+</h1>
+
+<% if api.description.present? %>
+  <%= render_markdown(unescape_newlines(api.description)) %>
+<% end %>
 
 <% if api.url.present? %>
-  <h2>Endpoint</h2>
   <p>
-    <code>
-      <%= api.url %>
-    </code>
+    The API endpoint is <code><%= api.url %></code>.
   </p>
 <% end %>
 
 <% if api.documentation.present? %>
-  <h2>Documentation</h2>
   <p>
-    <%= link_to(api.name + " documentation", api.documentation) %>
+  <% if api.name.include? "API" %>
+    Read the <%= link_to(api.name + " documentation", api.documentation) %>.
+  <% else %>
+    Read the <%= link_to(api.name + " API documentation", api.documentation) %>.
+  <% end %>
   </p>
+<% end %>
+
+<% if api.area_served.present? or api.start_date.present? or api.end_date.present? %>
+  <p>
+    This API:
+    <ul>
+  
+    <% if api.area_served.present? %>
+      <li>
+        covers <%= escape_html(api.area_served) %>
+      </li>
+    <% end %>
+
+    <% if api.start_date.present? %>
+      <li>
+        went live on <%= api.start_date.to_formatted_s(:rfc822) %>
+      </li>
+    <% end %>
+
+    <% if api.end_date.present? %>
+      <li>
+        closed on <%= api.end_date.to_formatted_s(:rfc822) %>
+      </li>
+    <% end %>
+
+    </ul>
+  </p>  
+  
 <% end %>
 
 <% if api.maintainer.present? %>
@@ -23,11 +61,6 @@
   </p>
 <% end %>
 
-<% if api.description.present? %>
-  <h2>Description</h2>
-  <%= render_markdown(unescape_newlines(api.description)) %>
-<% end %>
-
 <% if api.license.present? %>
   <h2>Licence</h2>
   <p>
@@ -35,23 +68,4 @@
   </p>
 <% end %>
 
-<% if api.area_served.present? %>
-  <h2>Geographic area</h2>
-  <p>
-    <%= escape_html(api.area_served) %>
-  </p>
-<% end %>
-
-<% if api.start_date.present? %>
-  <h2>Start date</h2>
-  <p>
-    <%= api.start_date.to_formatted_s(:rfc822) %>
-  </p>
-<% end %>
-
-<% if api.end_date.present? %>
-  <h2>Expiry date</h2>
-  <p>
-    <%= api.end_date.to_formatted_s(:rfc822) %>
-  </p>
-<% end %>
+</ul>

--- a/source/api_details.html.erb
+++ b/source/api_details.html.erb
@@ -29,7 +29,9 @@
 <% if api.area_served.present? or api.start_date.present? or api.end_date.present? %>
   <p>
     This API:
-    <ul>
+  </p>
+  
+  <ul>
   
     <% if api.area_served.present? %>
       <li>
@@ -49,8 +51,7 @@
       </li>
     <% end %>
 
-    </ul>
-  </p>  
+  </ul>
   
 <% end %>
 


### PR DESCRIPTION
This PR has some changes to the `api_details.html.erb` file, to rejig the API details page so it’s more in line with GOV.UK content standards and easier to read and use.

I’ve:

- moved the description to the top (and removed the ‘Description’ heading)
- moved the endpoint into a sentence in the main content, in line with GDS API documentation, and removed the ‘Endpoint’ heading 
- moved the documentation into a sentence in the main content, and removed the ‘Documentation’ heading
- moved the geographic area, start date and end date into a bulleted list in the main content
- added ‘API’ to the end of titles that don’t already have ‘API’ in their name - so the page title more accurately refers to the API (rather than just the subject of the API). This works especially well for APIs like Buckinghamshire Councils ‘Services’ API.

‘Licence’ and ‘Contact’ are a little trickier to work into page content so I’ve kept them out of scope for now.

I’ve tested with a selection of API detail pages and the only quirks I’ve seen are that:

- the new bullet list can sometimes only have one bullet in it, which is not in line with GOV.UK style - I’ll look into fixing this in a separate PR
- there are a couple of odd area bullets like ‘- covers Digital’, but that seems no more or less confusing than ‘Geographic area: Digital’.