### PR TITLE
Improve wording of "report problem" link

### DIFF
--- a/source/layouts/core.erb
+++ b/source/layouts/core.erb
@@ -62,7 +62,7 @@
             <% if config[:tech_docs][:show_contribution_banner] %>
               <ul class="contribution-banner">
                 <li><%= link_to "View source", source_urls.view_source_url %></li>
-                <li><%= link_to "Report problem", source_urls.report_issue_url %></li>
+                <li><%= link_to "Report a problem with this page's contents", source_urls.report_issue_url %></li>
                 <li><%= link_to "GitHub Repo", source_urls.repo_url %></li>
               </ul>
             <% end %>


### PR DESCRIPTION
We've had feedback that this isn't very clear, and leads to folks
believing it's for reporting issues with the API, rather than the
content on the page.

This wording should improve this, while we look at further tweaks to the
catalogue's wording.