### PR TITLE
Ensure co-cddo organisation is reference for this repo

### DIFF
--- a/.github/ISSUE_TEMPLATE/new-catalogue-entry-request.md
+++ b/.github/ISSUE_TEMPLATE/new-catalogue-entry-request.md
@@ -42,6 +42,6 @@ Optional - the acronym of the department or organisation. For example: 'GDS'.
 **Provider URL:**
 Optional - the canonical URL of the website of the department or organisation. For example: 'https://www.gov.uk/government/organisations/government-digital-service'.
 
-If you have multiple APIs to add, you can use a CSV template with these fields which is available at: https://raw.githubusercontent.com/alphagov/api-catalogue/HEAD/data/apic-csvtemplate.csv
+If you have multiple APIs to add, you can use a CSV template with these fields which is available at: https://raw.githubusercontent.com/co-cddo/api-catalogue/HEAD/data/apic-csvtemplate.csv
 
 Optionally, if you have more information you want to share with the API Catalogue community, please add it below.

--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This API catalogue is for central government and local government APIs.
 
-If you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/alphagov/api-catalogue/issues).
+If you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/co-cddo/api-catalogue/issues).
 
 Collecting a list of government APIs will help us understand:
 

--- a/bin/docker_serve
+++ b/bin/docker_serve
@@ -10,5 +10,5 @@ set -euo pipefail
 
 host_port=${PORT:-4567}
 
-docker build -t alphagov/api-catalogue:latest .
-docker run --publish "$host_port:4567" alphagov/api-catalogue:latest
+docker build -t co-cddo/api-catalogue:latest .
+docker run --publish "$host_port:4567" co-cddo/api-catalogue:latest

--- a/config/tech-docs.yml
+++ b/config/tech-docs.yml
@@ -18,4 +18,4 @@ header_links:
 prevent_indexing: false
 
 show_contribution_banner: true
-github_repo: alphagov/api-catalogue
+github_repo: co-cddo/api-catalogue

--- a/data/catalogue.csv-metadata.json
+++ b/data/catalogue.csv-metadata.json
@@ -3,7 +3,7 @@
   "url": "catalogue.csv",
   "schema:name": "UK government APIs",
   "schema:maintainer": "API Standards team <api-standards-request@digital.cabinet-office.gov.uk>",
-  "schema:description": "This API catalogue is for central government and local government APIs.\n\nIf you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/alphagov/api-catalogue/issues).\n\nCollecting a list of government APIs will help us understand:\n\n* what APIs are published\n* where API development is taking place\n* whether APIs are suitable for reuse",
+  "schema:description": "This API catalogue is for central government and local government APIs.\n\nIf you're working on an API that publishes open data or connects government with other organisations, industry or consumers, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by submitting a [GitHub Issue](https://github.com/co-cddo/api-catalogue/issues).\n\nCollecting a list of government APIs will help us understand:\n\n* what APIs are published\n* where API development is taking place\n* whether APIs are suitable for reuse",
   "tableSchema": {
     "primaryKey": "url",
     "foreignKeys": [{

--- a/docs/getting_started.md
+++ b/docs/getting_started.md
@@ -19,7 +19,7 @@ directory.
 
 ## Local setup
 
-1. Clone the git repository: `git clone git@github.com:alphagov/api-catalogue.git`
+1. Clone the git repository: `git clone git@github.com:co-cddo/api-catalogue.git`
 1. Navigate to the project directory: `cd api-catalogue`
 1. Install gems: `bundle install`
 1. Install JavaScript dependencies: `npm install`


### PR DESCRIPTION

Although GitHub applies the redirect for us, we should make sure that
we're still sending people to the correct location, which is on the new
organisation.