### PR TITLE
Ensure the word 'and' isn't removed from the display name

### DIFF
--- a/lib/fetcher/v1_alpha_fetcher.rb
+++ b/lib/fetcher/v1_alpha_fetcher.rb
@@ -43,8 +43,7 @@ class V1AlphaFetcher < Fetcher
   def create_organisation(name)
     id = create_organisation_id(name)
     alternate_name = if name.match(/\s/)
-                       name.slice! "and "
-                       name.split(/[ \-]/).map(&:first).join.downcase
+                       name.gsub("and", "").split(/[ \-]/).map(&:first).join.downcase
                      else
                        name
                      end

--- a/spec/lib/v1_alpha_fetcher_spec.rb
+++ b/spec/lib/v1_alpha_fetcher_spec.rb
@@ -115,6 +115,13 @@ RSpec.describe V1AlphaFetcher do
 
         expect(organisation.alternate_name).to eq "cddo"
       end
+
+      it "doesn't remove the word 'and' from the full name after creating the contracted version" do
+        name = "Central Digital and Data Office"
+        organisation = v1_alpha_fetcher.create_organisation(name)
+
+        expect(organisation.name).to eq "Central Digital and Data Office"
+      end
     end
   end
 end


### PR DESCRIPTION
We want to remove it to create the contracted version, but not change the name
that's actually displayed in the contents.