### PR TITLE
Update the footer content

### DIFF
--- a/source/layouts/_footer.erb
+++ b/source/layouts/_footer.erb
@@ -1,45 +1,52 @@
 <footer class="govuk-footer app-footer" role="contentinfo">
-  <div class="govuk-footer__meta">
-    <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
-
-      <% if config[:tech_docs][:footer_links] %>
-        <ul class="govuk-footer__inline-list">
-          <% config[:tech_docs][:footer_links].each do |title, path| %>
-            <li class="govuk-footer__inline-list-item">
-              <a class="govuk-footer__link" href="<%= url_for path %>"><%= title %></a>
-            </li>
-          <% end %>
+  <div class="govuk-width-container ">
+    <div class="govuk-footer__navigation">
+      <div class="govuk-footer__section govuk-grid-column-two-thirds">
+        <h2 class="govuk-footer__heading govuk-heading-m">Related resources</h2>
+        <ul class="govuk-footer__list govuk-footer__list--columns-2">
+          <li class="govuk-footer__list-item">
+            <a class="govuk-footer__link" href="/resources">
+              Supporting resources
+            </a>
+          </li>
+          <li class="govuk-footer__list-item">
+            <a class="govuk-footer__link" href="https://github.com/co-cddo/api-catalogue">
+              API catalogue Github repo
+            </a>
+          </li>
+          <li class="govuk-footer__list-item">
+            <a class="govuk-footer__link" href="https://www.gov.uk/guidance/gds-api-technical-and-data-standards">
+              API technical and data standards
+            </a>
+          </li>
         </ul>
-      <% end %>
-
-      <svg
-        aria-hidden="true"
-        focusable="false"
-        class="govuk-footer__licence-logo"
-        xmlns="http://www.w3.org/2000/svg"
-        viewbox="0 0 483.2 195.7"
-        height="17"
-        width="41"
-      >
-        <path
-          fill="currentColor"
-          d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145"
-        />
-      </svg>
-      <span class="govuk-footer__licence-description">
-        All content is available under the
-        <a
-          class="govuk-footer__link"
-          href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/"
-          rel="license"
-        >Open Government Licence v3.0</a>, except where otherwise stated
-      </span>
+      </div>
+      <div class="govuk-footer__section govuk-grid-column-one-third">
+        <h2 class="govuk-footer__heading govuk-heading-m">Support</h2>
+        <ul class="govuk-footer__list ">
+          <li class="govuk-footer__list-item">
+            <a class="govuk-footer__link" href="/accessibility.html">
+              Accessibility
+            </a>
+          </li>
+        </ul>
+      </div>
     </div>
-    <div class="govuk-footer__meta-item">
-      <a
-        class="govuk-footer__link govuk-footer__copyright-logo"
-        href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/"
-      >© Crown copyright</a>
+    <hr class="govuk-footer__section-break">
+    <div class="govuk-footer__meta">
+      <div class="govuk-footer__meta-item govuk-footer__meta-item--grow">
+
+        <svg aria-hidden="true" focusable="false" class="govuk-footer__licence-logo" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 483.2 195.7" height="17" width="41">
+          <path fill="currentColor" d="M421.5 142.8V.1l-50.7 32.3v161.1h112.4v-50.7zm-122.3-9.6A47.12 47.12 0 0 1 221 97.8c0-26 21.1-47.1 47.1-47.1 16.7 0 31.4 8.7 39.7 21.8l42.7-27.2A97.63 97.63 0 0 0 268.1 0c-36.5 0-68.3 20.1-85.1 49.7A98 98 0 0 0 97.8 0C43.9 0 0 43.9 0 97.8s43.9 97.8 97.8 97.8c36.5 0 68.3-20.1 85.1-49.7a97.76 97.76 0 0 0 149.6 25.4l19.4 22.2h3v-87.8h-80l24.3 27.5zM97.8 145c-26 0-47.1-21.1-47.1-47.1s21.1-47.1 47.1-47.1 47.2 21 47.2 47S123.8 145 97.8 145" />
+        </svg>
+        <span class="govuk-footer__licence-description">
+          All content is available under the
+          <a class="govuk-footer__link" href="https://www.nationalarchives.gov.uk/doc/open-government-licence/version/3/" rel="license">Open Government Licence v3.0</a>, except where otherwise stated
+        </span>
+      </div>
+      <div class="govuk-footer__meta-item">
+        <a class="govuk-footer__link govuk-footer__copyright-logo" href="https://www.nationalarchives.gov.uk/information-management/re-using-public-sector-information/uk-government-licensing-framework/crown-copyright/">© Crown copyright</a>
+      </div>
     </div>
   </div>
 </footer>

--- a/source/layouts/core.erb
+++ b/source/layouts/core.erb
@@ -61,9 +61,7 @@
           <aside>
             <% if config[:tech_docs][:show_contribution_banner] %>
               <ul class="contribution-banner">
-                <li><%= link_to "View source", source_urls.view_source_url %></li>
                 <li><%= link_to "Report a problem with this page's contents", source_urls.report_issue_url %></li>
-                <li><%= link_to "GitHub Repo", source_urls.repo_url %></li>
               </ul>
             <% end %>
           </aside>

--- a/source/resources/index.html.md
+++ b/source/resources/index.html.md
@@ -1,6 +1,7 @@
 ---
 title: Resources
 weight: 1
+hide_in_navigation: true
 ---
 # Supporting Resources
 


### PR DESCRIPTION

<img width="1440" alt="Screenshot 2022-04-20 at 16 45 53" src="https://user-images.githubusercontent.com/13121570/164270989-51f9314d-1e23-40e1-8e6a-1c2177941c66.png">


We don't want the resources link to be at the top of the navigation bar as it's
not part of the typical user journey, so these have been moved down to the
footer.

We've also removed the `View source` link as this doesn't work as expected and
isn't useful.

The 'Report a problem with this page' link is still in the page content above the footer,
as this is page-specific and we think the footer should contain links that are consistent across
the site.

We are planning to convert the 'Supporting resources' page into a communities page, with links through to the links and other pages in future.