### PR TITLE
Add curl to Docker build

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,6 +2,7 @@ FROM ruby:2.7-alpine
 WORKDIR /app
 
 RUN apk add --no-cache build-base nodejs npm
+RUN apk --no-cache add curl
 
 COPY package.json package-lock.json /app/
 RUN npm install


### PR DESCRIPTION
We were seeing the following error when running the Docker build: `LoadError:
Could not open library 'libcurl': Error loading shared library libcurl: No such
file or directory.`

The `html-proofer` gem depends on `typhoeus` which in turn depends on
`libcurl`, which needs `curl` to be installed. `curl` isn't automatically
included in Alpine Docker images so we need to add it manually.