### PR TITLE
Update URL for the FSA endpoint

### DIFF
--- a/data/registry_entries.csv
+++ b/data/registry_entries.csv
@@ -1,3 +1,3 @@
 baseurl
 https://federated-api-model-spring-boot-sandbox.london.cloudapps.digital
-https://raw.githubusercontent.com/co-cddo/api-catalogue-data-source/master/food-standards-agency
+https://raw.githubusercontent.com/co-cddo/api-catalogue-data-source/main/food-standards-agency


### PR DESCRIPTION
We've changed the default branch for the data source repo, so we need to update it here too