### PR TITLE
Add an endpoint for all apis found with federated model

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,3 +24,5 @@ spec/examples.txt
 /tmp
 
 node_modules
+
+source/apis

--- a/lib/provider.rb
+++ b/lib/provider.rb
@@ -1,0 +1,1 @@
+require_relative "provider/v1_alpha_provider"

--- a/lib/provider/v1_alpha_provider.rb
+++ b/lib/provider/v1_alpha_provider.rb
@@ -1,0 +1,27 @@
+class V1AlphaProvider
+  def self.retrieve_all(api_catalogues)
+    all_apis = []
+    api_catalogues.each do |catalogue|
+      catalogue.organisations_apis.each do |org, apis|
+        apis.each do |api|
+          metadata = {
+            "api-version": "api.gov.uk/v1alpha",
+            "data": {
+              "name": api.name,
+              "description": api.description,
+              "url": api.url,
+              "contact": api.maintainer,
+              "organisation": org.name,
+              "documentation-url": api.documentation,
+            },
+          }
+
+          all_apis.append(metadata)
+        end
+      end
+    end
+    version = { "api-version": "api.gov.uk/v1alpha" }
+    apis = { "apis": all_apis }
+    [version, apis].to_json
+  end
+end

--- a/spec/lib/test_data/all_apis.json
+++ b/spec/lib/test_data/all_apis.json
@@ -1,0 +1,31 @@
+[
+  {
+    "api-version": "api.gov.uk/v1alpha"
+  },
+  {
+    "apis": [
+      {
+        "api-version": "api.gov.uk/v1alpha",
+        "data": {
+          "name": "Test API One",
+          "description": "First test API",
+          "url": "example1.com",
+          "contact": "test@example1.com",
+          "organisation": null,
+          "documentation-url": "example1.com/docs"
+        }
+      },
+      {
+        "api-version": "api.gov.uk/v1alpha",
+        "data": {
+          "name": "Test API Two",
+          "description": "Second test API",
+          "url": "example2.com",
+          "contact": "test@example2.com",
+          "organisation": null,
+          "documentation-url": "example2.com/docs"
+        }
+      }
+    ]
+  }
+]

--- a/spec/lib/test_data/all_apis_multiple_catalogues.json
+++ b/spec/lib/test_data/all_apis_multiple_catalogues.json
@@ -1,0 +1,42 @@
+[
+  {
+    "api-version": "api.gov.uk/v1alpha"
+  },
+  {
+    "apis": [
+      {
+        "api-version": "api.gov.uk/v1alpha",
+        "data": {
+          "name": "Test API One",
+          "description": "First test API",
+          "url": "example1.com",
+          "contact": "test@example1.com",
+          "organisation": null,
+          "documentation-url": "example1.com/docs"
+        }
+      },
+      {
+        "api-version": "api.gov.uk/v1alpha",
+        "data": {
+          "name": "Test API Two",
+          "description": "Second test API",
+          "url": "example2.com",
+          "contact": "test@example2.com",
+          "organisation": null,
+          "documentation-url": "example2.com/docs"
+        }
+      },
+      {
+        "api-version": "api.gov.uk/v1alpha",
+        "data": {
+          "name": "Test API Three",
+          "description": "Third test API",
+          "url": "example3.com",
+          "contact": "test@example3.com",
+          "organisation": null,
+          "documentation-url": "example3.com/docs"
+        }
+      }
+    ]
+  }
+]

--- a/spec/lib/v1_alpha_provider_spec.rb
+++ b/spec/lib/v1_alpha_provider_spec.rb
@@ -1,0 +1,36 @@
+require "provider"
+require "organisation"
+require "api_catalogue"
+
+RSpec.describe V1AlphaProvider do
+  describe "::retrieve_all" do
+    it "returns all the APIs" do
+      api_one = Api.new name: "Test API One", description: "First test API", url: "example1.com", maintainer: "test@example1.com", documentation: "example1.com/docs", provider: "Test Org One"
+      api_two = Api.new name: "Test API Two", description: "Second test API", url: "example2.com", maintainer: "test@example2.com", documentation: "example2.com/docs", provider: "Test Org One"
+      org_one = Organisation.new id: "Test Org One"
+      catalogue_one = ApiCatalogue.new(apis: [api_one, api_two], organisations: [org_one])
+
+      result = JSON.parse(described_class.retrieve_all([catalogue_one]))
+
+      expected = JSON.parse(File.read("spec/lib/test_data/all_apis.json"))
+
+      expect(result).to eq expected
+    end
+
+    it "returns all the APIs from multiple catalogues" do
+      api_one = Api.new name: "Test API One", description: "First test API", url: "example1.com", maintainer: "test@example1.com", documentation: "example1.com/docs", provider: "Test Org One"
+      api_two = Api.new name: "Test API Two", description: "Second test API", url: "example2.com", maintainer: "test@example2.com", documentation: "example2.com/docs", provider: "Test Org One"
+      org_one = Organisation.new id: "Test Org One"
+      api_three = Api.new name: "Test API Three", description: "Third test API", url: "example3.com", maintainer: "test@example3.com", documentation: "example3.com/docs", provider: "Test Org Two"
+      org_two = Organisation.new id: "Test Org Two"
+      catalogue_one = ApiCatalogue.new(apis: [api_one, api_two], organisations: [org_one])
+      catalogue_two = ApiCatalogue.new(apis: [api_three], organisations: [org_two])
+
+      result = JSON.parse(described_class.retrieve_all([catalogue_one, catalogue_two]))
+
+      expected = JSON.parse(File.read("spec/lib/test_data/all_apis_multiple_catalogues.json"))
+
+      expect(result).to eq expected
+    end
+  end
+end


### PR DESCRIPTION
This means that other catalogues will be able to consume this catalogue using
our federated model of data discovery:
https://github.com/co-cddo/federated-api-model/blob/arnau-handover/design/artefacts/system-context.svg

As this is a static site we don't currently have storage for apis, so this is
slightly different to our model.

Also as this is a static site, to create the 'endpoint' we create a temporary
file that gets copied to the build folder.

For the tests we're comparing the parsed json rather than the raw json strings,
as this allows us to store the expected result in a separate formatted json
file which is more readable, and allows us to compare the actual values.

We're only using this for apis we ingest using the federated model, as we know
these ones follow our schema.