### PR TITLE
Revert "Bump govuk-frontend from 4.7.0 to 4.8.0"

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,7 +7,7 @@
       "name": "api-catalogue",
       "license": "MIT",
       "dependencies": {
-        "govuk-frontend": "^4.8.0",
+        "govuk-frontend": "^4.7.0",
         "jquery": "^3",
         "lodash": "^4.17.21",
         "mark.js": "^8.11.1",
@@ -1295,9 +1295,9 @@
       }
     },
     "node_modules/govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==",
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==",
       "engines": {
         "node": ">= 4.2.0"
       }
@@ -3721,9 +3721,9 @@
       }
     },
     "govuk-frontend": {
-      "version": "4.8.0",
-      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.8.0.tgz",
-      "integrity": "sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw=="
+      "version": "4.7.0",
+      "resolved": "https://registry.npmjs.org/govuk-frontend/-/govuk-frontend-4.7.0.tgz",
+      "integrity": "sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg=="
     },
     "graceful-fs": {
       "version": "4.2.11",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
     "lint": "standard"
   },
   "dependencies": {
-    "govuk-frontend": "^4.8.0",
+    "govuk-frontend": "^4.7.0",
     "jquery": "^3",
     "lodash": "^4.17.21",
     "mark.js": "^8.11.1",

--- a/yarn.lock
+++ b/yarn.lock
@@ -717,10 +717,10 @@ gopd@^1.0.1:
   dependencies:
     get-intrinsic "^1.1.3"
 
-govuk-frontend@^4.8.0:
-  version "4.8.0"
-  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.8.0.tgz#df4e56c762e93aae74fed214bb6be08e13783772"
-  integrity sha512-NOmPJxL8IYq1HSNHYKx9XY2LLTxuwb+IFASiGQO4sgJ8K7AG66SlSeqARrcetevV8zOf+i1z+MbJJ2O7//OxAw==
+govuk-frontend@^4.7.0:
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/govuk-frontend/-/govuk-frontend-4.7.0.tgz#69950b6c2e69f435ffe9aa60d8dee232dac977de"
+  integrity sha512-0OsdCusF5qvLWwKziU8zqxiC0nq6WP0ZQuw51ymZ/1V0tO71oIKMlSLN2S9bm8RcEGSoidPt2A34gKxePrLjvg==
 
 graceful-fs@^4.1.15:
   version "4.2.11"


### PR DESCRIPTION
This reverts commit b4c586d5bbc6fefdfd4bb58d99d2ea8f7fdd84df. as I appears to have broken the site's styling