### PR TITLE
Remove references to CDDO and scope of project description on home page

### DIFF
--- a/source/index.html.md
+++ b/source/index.html.md
@@ -7,8 +7,6 @@ weight: 1
 
 This catalogue is for APIs published by public sector organisations in the UK.
 
-If you're working on an API that publishes open data or connects government with users from other organisations or wider industry, we’d like to invite you to publish details of it in this catalogue. You can publish details of your API by [creating an issue in the API Catalogue GitHub repo](https://github.com/co-cddo/api-catalogue/issues/new/choose).
-
 Collecting a list of government APIs helps us understand:
 
 * what APIs are published
@@ -21,20 +19,4 @@ All of the APIs and data sources published in the catalogue have their own licen
 
 **Note**: An API appearing on this catalogue does not mean it will be publicly accessible, nor is it a requirement. This is a public-facing site to allow us to document and discover APIs that are available and in use.
 
-## Get in touch
-
-The API Catalogue is a central part of the [Data Standards Authority's](https://www.gov.uk/government/groups/data-standards-authority) API programme, which aims to improve how APIs are produced, managed and used across government. For more information, or to ask to be added to the government API & Data Exchange community, email <api-programme@digital.cabinet-office.gov.uk>.
-
-If you have any questions about the catalogue, or how to add your APIs to it, email <api-catalogue@digital.cabinet-office.gov.uk>. We aim to respond to queries as soon as possible, but please be aware we don't have visibility of other government APIs that are not in the catalogue. You may get a faster response for queries like that from the relevant department.
-
-If you are looking to set up an api.gov.uk domain for your API, email <api-domain-request@digital.cabinet-office.gov.uk>.
-
-## API Survey
-
-If you work for government or in a public sector organisation we would appreciate your time and effort in completing a survey about APIs at your organisation. Your feedback will be used to inform the work of [Central Digital & Data Office](https://www.gov.uk/government/organisations/central-digital-and-data-office) in setting API guidance and standards for government.
-
-The survey is a list of questions on API operations, management, strategy, platform usage, governance and security at your organisation.  Please review the questions and provide your responses, there are 36 questions in total, and the majority are multiple-choice so the survey should only take around 20 minutes to complete.
-
-Your insights and feedback are valuable, and we kindly invite you to share your thoughts and opinions as you complete the survey from your own perspective within your organisation. We optionally ask you to share your email address so that we can follow-up with you if you are able to take part in future research, but any responses you give will be kept anonymous and your email address will not be shared further.
-
-Please access the survey via this link: [CDDO API Survey](https://forms.gle/q3ZP884KTrJqK9rF6)
+The API Catalogue is a central part of the [Data Standards Authority's](https://www.gov.uk/government/groups/data-standards-authority) API programme, which aims to improve how APIs are produced, managed and used across government.


### PR DESCRIPTION
With this update the home page looks like this:

<img width="1577" alt="home_page_without_cddo_content" src="https://github.com/user-attachments/assets/770d431f-1bee-4452-8cdd-caf29ccd3e49" />
