### PR TITLE
feat: add bulk CSV processing specs and bin/test utility

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -286,6 +286,7 @@ GEM
 PLATFORMS
   aarch64-linux-musl
   arm64-darwin-21
+  arm64-darwin-25
   x86_64-linux
 
 DEPENDENCIES

--- a/bin/test
+++ b/bin/test
@@ -1,0 +1,149 @@
+#!/usr/bin/env bash
+
+# Runs the RSpec test suite.
+#
+# Usage:
+#   bin/test                  Run the whole suite
+#   bin/test bulk             Run spec/lib/api_catalogue_spec.rb
+#   bin/test context          Run only the "bulk import from synthetic CSV fixtures" context
+#   bin/test line <N>         Run the example at spec/lib/api_catalogue_spec.rb:<N>
+#   bin/test -h | --help      Show this help
+#
+# Verbosity (env vars):
+#   QUIET=1      Suppress the documentation format (use default progress dots)
+#   PROFILE=1    Append --profile to show the 10 slowest examples
+#   TRACE=1      Print each shell command as it runs (set -x)
+#
+# Any extra arguments after the subcommand are forwarded to rspec, e.g.:
+#   bin/test bulk --fail-fast
+#   bin/test -- --tag focus
+
+set -euo pipefail
+
+if [[ "${TRACE:-0}" == "1" ]]; then
+  set -x
+fi
+
+REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
+cd "$REPO_ROOT"
+
+BULK_SPEC="spec/lib/api_catalogue_spec.rb"
+BULK_CONTEXT="bulk import from synthetic CSV fixtures"
+
+if [[ -t 2 ]]; then
+  C_DIM='\033[2m'; C_BOLD='\033[1m'; C_GREEN='\033[32m'; C_YELLOW='\033[33m'; C_RESET='\033[0m'
+else
+  C_DIM=''; C_BOLD=''; C_GREEN=''; C_YELLOW=''; C_RESET=''
+fi
+
+log()  { printf "${C_DIM}[bin/test]${C_RESET} %b\n" "$*" >&2; }
+step() { printf "${C_BOLD}${C_GREEN}==>${C_RESET} %b\n" "$*" >&2; }
+warn() { printf "${C_BOLD}${C_YELLOW}!! ${C_RESET} %b\n" "$*" >&2; }
+
+usage() {
+  sed -n '3,19p' "$0" | sed 's/^# \{0,1\}//'
+}
+
+required_ruby=$(cat .ruby-version 2>/dev/null || echo "")
+required_bundler=$(awk '/BUNDLED WITH/{getline; gsub(/ /,""); print; exit}' Gemfile.lock 2>/dev/null || echo "")
+
+preflight() {
+  step "Preflight checks"
+
+  local active_ruby
+  active_ruby=$(ruby -e 'print RUBY_VERSION' 2>/dev/null || echo "none")
+  log "ruby:    $(command -v ruby || echo 'not found') ($active_ruby)"
+  log "needed:  $required_ruby (from .ruby-version)"
+
+  if [[ "$active_ruby" != "$required_ruby" ]]; then
+    cat >&2 <<EOF
+
+bin/test: wrong Ruby active.
+  required: $required_ruby (from .ruby-version)
+  active:   $active_ruby ($(command -v ruby || echo 'not found'))
+
+Fix:
+  1. rbenv install $required_ruby
+  2. Add rbenv to your shell (one-time):
+       echo 'eval "\$(rbenv init - zsh)"' >> ~/.zshrc
+       exec zsh
+  3. gem install bundler -v $required_bundler
+  4. bundle install
+EOF
+    exit 69
+  fi
+
+  if ! bundle --version >/dev/null 2>&1; then
+    warn "bundler not available for Ruby $required_ruby"
+    echo "Run: gem install bundler -v $required_bundler" >&2
+    exit 69
+  fi
+  log "bundler: $(bundle --version)"
+
+  log "checking gem dependencies..."
+  if ! bundle check >/dev/null 2>&1; then
+    warn "gems are missing"
+    echo "Run: bundle install" >&2
+    exit 69
+  fi
+  log "gem dependencies satisfied"
+}
+
+# Default rspec flags. Documentation format with colour so each example name
+# is printed as it runs. Override with QUIET=1 or PROFILE=1.
+DEFAULT_RSPEC_ARGS=()
+if [[ "${QUIET:-0}" != "1" ]]; then
+  DEFAULT_RSPEC_ARGS+=(--format documentation --color)
+fi
+if [[ "${PROFILE:-0}" == "1" ]]; then
+  DEFAULT_RSPEC_ARGS+=(--profile)
+fi
+
+run_rspec() {
+  local label="$1"; shift
+
+  step "Running: $label"
+  log "command: bundle exec rspec ${DEFAULT_RSPEC_ARGS[*]:-} $*"
+  echo >&2
+  exec bundle exec rspec ${DEFAULT_RSPEC_ARGS[@]+"${DEFAULT_RSPEC_ARGS[@]}"} "$@"
+}
+
+cmd=${1:-suite}
+[[ $# -gt 0 ]] && shift || true
+
+case "$cmd" in
+  -h|--help|help)
+    usage
+    exit 0
+    ;;
+  suite|all|"")
+    preflight
+    run_rspec "whole suite" "$@"
+    ;;
+  bulk|spec)
+    preflight
+    run_rspec "bulk-import spec ($BULK_SPEC)" "$BULK_SPEC" "$@"
+    ;;
+  context)
+    preflight
+    run_rspec "context: \"$BULK_CONTEXT\"" "$BULK_SPEC" -e "$BULK_CONTEXT" "$@"
+    ;;
+  line)
+    if [[ $# -lt 1 ]]; then
+      echo "error: 'line' needs a line number, e.g. bin/test line 36" >&2
+      exit 64
+    fi
+    line=$1; shift
+    preflight
+    run_rspec "single example at ${BULK_SPEC}:${line}" "${BULK_SPEC}:${line}" "$@"
+    ;;
+  --)
+    preflight
+    run_rspec "rspec with passthrough args" "$@"
+    ;;
+  *)
+    echo "error: unknown command '$cmd'" >&2
+    usage >&2
+    exit 64
+    ;;
+esac

--- a/bin/test
+++ b/bin/test
@@ -5,7 +5,7 @@
 # Usage:
 #   bin/test                  Run the whole suite
 #   bin/test bulk             Run spec/lib/api_catalogue_spec.rb
-#   bin/test context          Run only the "bulk import from synthetic CSV fixtures" context
+#   bin/test context          Run only the "with synthetic CSV fixtures for bulk import" context
 #   bin/test line <N>         Run the example at spec/lib/api_catalogue_spec.rb:<N>
 #   bin/test -h | --help      Show this help
 #
@@ -28,7 +28,7 @@ REPO_ROOT=$(cd "$(dirname "$0")/.." && pwd)
 cd "$REPO_ROOT"
 
 BULK_SPEC="spec/lib/api_catalogue_spec.rb"
-BULK_CONTEXT="bulk import from synthetic CSV fixtures"
+BULK_CONTEXT="with synthetic CSV fixtures for bulk import"
 
 if [[ -t 2 ]]; then
   C_DIM='\033[2m'; C_BOLD='\033[1m'; C_GREEN='\033[32m'; C_YELLOW='\033[33m'; C_RESET='\033[0m'

--- a/spec/lib/api_catalogue_spec.rb
+++ b/spec/lib/api_catalogue_spec.rb
@@ -1,4 +1,5 @@
 require "api_catalogue"
+require "tempfile"
 require "webmock/rspec"
 
 RSpec.describe ApiCatalogue do
@@ -32,6 +33,111 @@ RSpec.describe ApiCatalogue do
         description: be_present,
         url: "https://api.notifications.service.gov.uk/",
       )
+    end
+
+    context "bulk import from synthetic CSV fixtures" do
+      def with_csvs(catalogue_content, organisation_content)
+        Tempfile.create(["catalogue", ".csv"]) do |cat_file|
+          Tempfile.create(["organisation", ".csv"]) do |org_file|
+            cat_file.write(catalogue_content)
+            cat_file.flush
+            org_file.write(organisation_content)
+            org_file.flush
+            yield cat_file.path, org_file.path
+          end
+        end
+      end
+
+      let(:organisations_csv) do
+        <<~CSV
+          id,name,alternateName,url
+          example-dept,Example Department,EXD,https://example.gov.uk
+          other-dept,Other Department,OD,https://other.gov.uk
+        CSV
+      end
+
+      let(:apis_csv) do
+        <<~CSV
+          dateAdded,dateUpdated,url,name,description,documentation,license,maintainer,areaServed,startDate,endDate,provider
+          2024-01-15,2024-02-01,https://api.example.gov.uk/one,API One,First API,https://docs/one,MIT,team@example.gov.uk,UK,2024-01-01,,example-dept
+          2024-03-10,2024-03-10,https://api.example.gov.uk/two,API Two,Second API,https://docs/two,MIT,team@example.gov.uk,UK,,,example-dept
+          2024-04-01,2024-04-01,https://api.other.gov.uk/three,API Three,Third API,https://docs/three,MIT,team@other.gov.uk,UK,,,other-dept
+        CSV
+      end
+
+      it "imports every row and groups APIs under their providing organisation" do
+        with_csvs(apis_csv, organisations_csv) do |cat_path, org_path|
+          catalogue = described_class.from_csv(catalogue_csv: cat_path, organisation_csv: org_path)
+
+          expect(catalogue.organisations_apis.keys.map(&:name))
+            .to contain_exactly("Example Department", "Other Department")
+
+          example, example_apis = catalogue.organisations_apis.detect { |o, _| o.name == "Example Department" }
+          expect(example.alternate_name).to eq("EXD")
+          expect(example_apis.map(&:name)).to eq(["API One", "API Two"])
+
+          _, other_apis = catalogue.organisations_apis.detect { |o, _| o.name == "Other Department" }
+          expect(other_apis.map(&:name)).to eq(["API Three"])
+        end
+      end
+
+      it "coerces date columns into Date instances" do
+        with_csvs(apis_csv, organisations_csv) do |cat_path, org_path|
+          catalogue = described_class.from_csv(catalogue_csv: cat_path, organisation_csv: org_path)
+
+          api_one = catalogue.organisations_apis.values.flatten.detect { |a| a.name == "API One" }
+
+          expect(api_one.date_added).to eq(Date.new(2024, 1, 15))
+          expect(api_one.date_updated).to eq(Date.new(2024, 2, 1))
+          expect(api_one.start_date).to eq(Date.new(2024, 1, 1))
+          expect(api_one.end_date).to be_nil
+        end
+      end
+
+      it "keeps organisations with no published APIs in the grouping with an empty list" do
+        orgs = <<~CSV
+          id,name,alternateName,url
+          empty-dept,Empty Department,ED,https://empty.gov.uk
+          example-dept,Example Department,EXD,https://example.gov.uk
+        CSV
+        apis = <<~CSV
+          dateAdded,dateUpdated,url,name,description,documentation,license,maintainer,areaServed,startDate,endDate,provider
+          2024-01-15,2024-02-01,https://api.example.gov.uk/one,API One,First API,https://docs/one,MIT,team,UK,,,example-dept
+        CSV
+
+        with_csvs(apis, orgs) do |cat_path, org_path|
+          catalogue = described_class.from_csv(catalogue_csv: cat_path, organisation_csv: org_path)
+
+          empty_org, empty_apis = catalogue.organisations_apis.detect { |o, _| o.name == "Empty Department" }
+          expect(empty_org).not_to be_nil
+          expect(empty_apis).to eq([])
+        end
+      end
+
+      it "drops imported APIs whose provider does not match any organisation" do
+        orphan_apis = <<~CSV
+          dateAdded,dateUpdated,url,name,description,documentation,license,maintainer,areaServed,startDate,endDate,provider
+          2024-01-15,2024-02-01,https://api.example.gov.uk/ghost,Ghost API,Orphan,https://docs/ghost,MIT,team,UK,,,unknown-dept
+        CSV
+
+        with_csvs(orphan_apis, organisations_csv) do |cat_path, org_path|
+          catalogue = described_class.from_csv(catalogue_csv: cat_path, organisation_csv: org_path)
+
+          expect(catalogue.organisations_apis.values.flatten).to be_empty
+          expect(catalogue.organisations_apis.keys).not_to be_empty
+        end
+      end
+
+      it "produces an empty catalogue when both CSVs contain only headers" do
+        empty_apis = "dateAdded,dateUpdated,url,name,description,documentation,license,maintainer,areaServed,startDate,endDate,provider\n"
+        empty_orgs = "id,name,alternateName,url\n"
+
+        with_csvs(empty_apis, empty_orgs) do |cat_path, org_path|
+          catalogue = described_class.from_csv(catalogue_csv: cat_path, organisation_csv: org_path)
+
+          expect(catalogue.organisations_apis).to eq({})
+        end
+      end
     end
   end
 

--- a/spec/lib/api_catalogue_spec.rb
+++ b/spec/lib/api_catalogue_spec.rb
@@ -35,7 +35,7 @@ RSpec.describe ApiCatalogue do
       )
     end
 
-    context "bulk import from synthetic CSV fixtures" do
+    context "with synthetic CSV fixtures for bulk import" do
       def with_csvs(catalogue_content, organisation_content)
         Tempfile.create(["catalogue", ".csv"]) do |cat_file|
           Tempfile.create(["organisation", ".csv"]) do |org_file|

--- a/spec/lib/csv_source_spec.rb
+++ b/spec/lib/csv_source_spec.rb
@@ -1,0 +1,55 @@
+require "csv_source"
+require "tempfile"
+
+RSpec.describe CsvSource do
+  describe "::load" do
+    def with_csv(contents)
+      Tempfile.create(["bulk", ".csv"]) do |file|
+        file.write(contents)
+        file.flush
+        yield file.path
+      end
+    end
+
+    it "yields each row in a bulk CSV with underscored symbol keys" do
+      csv = <<~CSV
+        url,name,description,documentation,maintainer,provider,providerUrl
+        https://api.example.gov.uk/one,API One,First API,https://docs.example.gov.uk/one,team-one@example.gov.uk,Example Department,https://example.gov.uk
+        https://api.example.gov.uk/two,API Two,Second API,https://docs.example.gov.uk/two,team-two@example.gov.uk,Example Department,https://example.gov.uk
+        https://api.example.gov.uk/three,API Three,Third API,https://docs.example.gov.uk/three,team-three@example.gov.uk,Other Department,https://other.gov.uk
+      CSV
+
+      with_csv(csv) do |path|
+        rows = described_class.load(path) { |row| row }
+
+        expect(rows.size).to eq(3)
+        expect(rows.first).to include(
+          url: "https://api.example.gov.uk/one",
+          name: "API One",
+          provider: "Example Department",
+          provider_url: "https://example.gov.uk",
+        )
+        expect(rows.map { |r| r[:name] }).to eq(["API One", "API Two", "API Three"])
+      end
+    end
+
+    it "returns the values produced by the block for every row" do
+      csv = <<~CSV
+        url,name
+        https://a,Alpha
+        https://b,Bravo
+      CSV
+
+      with_csv(csv) do |path|
+        names = described_class.load(path) { |row| row[:name] }
+        expect(names).to eq(%w[Alpha Bravo])
+      end
+    end
+
+    it "returns an empty array when the CSV has only a header row" do
+      with_csv("url,name\n") do |path|
+        expect(described_class.load(path) { |row| row }).to eq([])
+      end
+    end
+  end
+end


### PR DESCRIPTION
Tests for bulk CSV imports in `api_catalogue` and `csv_source`. Add a `bin/test` script to streamline running RSpec with various options.

**To start a test navigate to bin directory:**
```api-catalogue % bin/test```

**Output:**
```
==> Preflight checks
[bin/test] ruby:    /Users/haresh.kainth/.rbenv/shims/ruby (3.2.2)
[bin/test] needed:  3.2.2 (from .ruby-version)
[bin/test] bundler: Bundler version 2.3.26
[bin/test] checking gem dependencies...
[bin/test] gem dependencies satisfied
==> Running: whole suite
[bin/test] command: bundle exec rspec --format documentation --color 

/Users/haresh.kainth/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/io-event-1.10.0/lib/io/event/support.rb:48: warning: IO::Buffer is experimental and both the Ruby and C interface may change in the future!

Randomized with seed 44100
/Users/haresh.kainth/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support/core_ext/time/deprecated_conversions.rb:42: warning: method redefined; discarding old to_s
/Users/haresh.kainth/.rbenv/versions/3.2.2/lib/ruby/gems/3.2.0/gems/activesupport-7.0.8.7/lib/active_support/time_with_zone.rb:210: warning: previous definition of to_s was here

FetcherService
  #fetch
    returns the list of APIs when the fetcher succeeds
    bubbles up a TemporaryError if one is raised
    bubbles up a ClientError if one is raised
    raises a ClientError if we weren't able to successfully fetch anything
    only goes to fetcher2 if fetcher1 raises an error
    delegates to a configured fetcher

V1AlphaFetcher
  #fetch
    not found
      raises NoVersionFound
    ::create_organisation
      creates an id using a camel case, lowercase version of the name
      creates a contraction for the alternative name if it contains multiple words
      uses the name for the alternative name if it's a single word
      removes the word 'and' from alternative name to create the contracted version
      doesn't remove the word 'and' from the full name after creating the contracted version
    bad request
      raises ClientError
    not accepted
      raises NoVersionAcceptable
    success
      parses APIs
    temporary error
      raises TemporaryError

FormatHelpers
  #render_markdown
    renders HTML from the markdown content
    autolinks any URLs which aren't normal markdown links
  #unescape_newlines
    converts escaped newlines into unescaped, literal newlines

UrlHelpers
  append_querystring
    creates querystring if not present
    does not support invalid URIs
    appends to existing querystring if present
    does not support invalid URIs
    doesn't require query to override
    does not support invalid URIs
    does not support invalid URIs
    ignores everything but the first querystring parameter

ApiCatalogue
  ::merge
    merges two catalogues together
    does not add duplicate APIs
    does not add duplicate organisations
  ordering
    sorts organisations and APIs from A-Z
  ::from_csv
    parses the CSV sources
    bulk import from synthetic CSV fixtures
      drops imported APIs whose provider does not match any organisation
      coerces date columns into Date instances
      imports every row and groups APIs under their providing organisation
      produces an empty catalogue when both CSVs contain only headers
      keeps organisations with no published APIs in the grouping with an empty list
  ::from_url
    returns an empty catalogue if a 404 error is raised
    returns an empty catalogue if a 406 error is raised
  ::from_urls
    parses the CSV source

V1AlphaProvider
  ::retrieve_all
    returns all the APIs
    returns all the APIs from multiple catalogues

CsvSource
  ::load
    returns an empty array when the CSV has only a header row
    yields each row in a bulk CSV with underscored symbol keys
    returns the values produced by the block for every row

DashboardStats
  #total_organisations
    sums the number of organisations
  #total_apis
    sums the APIs across each organisation
  #by_organisation
    provides stats per organisation
    orders the organisations by number of APIs

Finished in 0.17923 seconds (files took 0.64544 seconds to load)
49 examples, 0 failures
```