### PR TITLE
Add planning.data.gov.uk

### DIFF
--- a/data/catalogue.csv
+++ b/data/catalogue.csv
@@ -1790,3 +1790,4 @@ This integration uses a publish-subscribe model - the sending system publishes
 For example, when a GP system records a vaccination, it sends an event message containing the vaccination details to NEMS. NEMS then sends the message to all healthcare workers who have subscribed to receive vaccination event messages. 
 
 ",https://digital.nhs.uk/developer/api-catalogue/vaccination-events-fhir,,https://digital.nhs.uk/developer/help-and-support,,,,nhs-digital
+2026-06-09,2026-06-09,https://www.planning.data.gov.uk/,Planning and housing data in England,"Planning and housing data in England provides access to datasets about planning and housing across England. The service brings together data from many organisations and makes it available as open data for use by developers, researchers, and planning authorities.",https://www.planning.data.gov.uk/docs,,digitalland@communities.gov.uk,England,,,ministry-of-housing-communities-local-government

--- a/data/catalogue.csv
+++ b/data/catalogue.csv
@@ -1790,4 +1790,16 @@ This integration uses a publish-subscribe model - the sending system publishes
 For example, when a GP system records a vaccination, it sends an event message containing the vaccination details to NEMS. NEMS then sends the message to all healthcare workers who have subscribed to receive vaccination event messages. 
 
 ",https://digital.nhs.uk/developer/api-catalogue/vaccination-events-fhir,,https://digital.nhs.uk/developer/help-and-support,,,,nhs-digital
-2026-06-09,2026-06-09,https://www.planning.data.gov.uk/,Planning and housing data in England,"Planning and housing data in England provides access to datasets about planning and housing across England. The service brings together data from many organisations and makes it available as open data for use by developers, researchers, and planning authorities.",https://www.planning.data.gov.uk/docs,,digitalland@communities.gov.uk,England,,,ministry-of-housing-communities-local-government
+2026-06-09,2026-06-09,https://www.planning.data.gov.uk/,Planning and housing data in England (planning.data.gov.uk),"Planning and housing data in England (planning.data.gov.uk) provides access to datasets about planning and housing across England. The service brings together data from many organisations and makes it available as open data for use by developers, researchers, and planning authorities.
+
+Use this API to
+
+- check planning constraints for a location
+- find development sites in an area
+- research heritage and environmental designations
+- monitor new planning applications
+- screen a portfolio against planning risk
+
+and much more. 
+
+You can query by CURIE, co-ordinate, UPRN, and by area (administrative, statistical, or custom boundaries).",https://www.planning.data.gov.uk/docs,,https://www.planning.data.gov.uk/about/contact,England,,,ministry-of-housing-communities-local-government


### PR DESCRIPTION
This pull request adds planning.data.gov.uk to the API catalogue, after https://github.com/co-cddo/api-catalogue/issues/1165 was closed by the API Catalogue team.