### PR TITLE
docs: add contributing guide with guidelines and contact details

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,33 @@
+# Contributing
+
+Thank you for your interest in the API Catalogue. There are two main ways to contribute.
+
+## Updating out-of-date content
+
+The information about each API is owned by the data source owner, not by this
+repository. If you find that content for an API is out of date or incorrect,
+please contact the relevant data source owner and ask them to update the entry
+by submitting a [pull request](https://github.com/co-cddo/api-catalogue/pulls).
+
+## Reporting a technical issue
+
+If there is a technical problem with the API catalogue itself, please
+[open an issue](https://github.com/co-cddo/api-catalogue/issues).
+
+### Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting the project team at api-catalogue@digital.cabinet-office.gov.uk. All
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. The project team is
+obligated to maintain confidentiality with regard to the reporter of an incident.
+Further details of specific enforcement policies may be posted separately.
+
+Project maintainers who do not follow or enforce the Code of Conduct in good
+faith may face temporary or permanent repercussions as determined by other
+members of the project's leadership.
+
+## Code of conduct
+
+By participating in this project you agree to abide by our
+[Code of Conduct](./CODE_OF_CONDUCT.md). Abuse of any kind is not tolerated.


### PR DESCRIPTION
Add a contributing.md file with reference to code of conduct guide. Expect this document to be refined in the near future.